### PR TITLE
Refactor app and main modules

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@
  * Following functional programming principles and Generative Analysis specification
  */
 
+import { createServerManager } from './serverManager.js';
 // Handle potential errors gracefully
 window.addEventListener('error', (event) => {
     console.log('Window error caught:', event.error);
@@ -25,252 +26,6 @@ let appState = {
 };
 
 // Project server state management
-const SERVER_STATUS = {
-    STOPPED: 'stopped',
-    STARTING: 'starting', 
-    READY: 'ready',
-    FAILED: 'failed'
-};
-
-function createProjectServerState(projectId) {
-    return {
-        projectId,
-        status: SERVER_STATUS.STOPPED,
-        url: null,
-        port: null,
-        pid: null,
-        startTime: null,
-        lastError: null
-    };
-}
-
-function updateProjectServerState(projectId, updates) {
-    const currentState = appState.projectServers.get(projectId) || createProjectServerState(projectId);
-    const newState = { ...currentState, ...updates };
-    appState.projectServers.set(projectId, newState);
-    
-    // Update UI indicators
-    updateServerStatusIndicator(newState);
-    
-    return newState;
-}
-
-function getProjectServerState(projectId) {
-    return appState.projectServers.get(projectId) || createProjectServerState(projectId);
-}
-
-function isServerReady(projectId) {
-    const state = getProjectServerState(projectId);
-    return state.status === SERVER_STATUS.READY && state.url;
-}
-
-// Background server startup (non-blocking)
-async function startProjectServerBackground(projectId) {
-    console.log('🚀 Starting dev server in background for project:', projectId);
-    
-    // Update state to starting
-    updateProjectServerState(projectId, {
-        status: SERVER_STATUS.STARTING,
-        startTime: Date.now()
-    });
-    
-    try {
-        // Check if already running first
-        const statusResult = await window.electronAPI.getProjectServerStatus(projectId);
-        if (statusResult.success && statusResult.status === 'running') {
-            console.log('✅ Server already running for project:', projectId);
-            updateProjectServerState(projectId, {
-                status: SERVER_STATUS.READY,
-                url: statusResult.url,
-                port: statusResult.port,
-                pid: statusResult.pid
-            });
-            return;
-        }
-        
-        // Start new server
-        const startResult = await window.electronAPI.startProjectServer(projectId);
-        if (startResult.success) {
-            console.log('✅ Server started successfully for project:', projectId);
-            updateProjectServerState(projectId, {
-                status: SERVER_STATUS.READY,
-                url: startResult.url,
-                port: startResult.port,
-                pid: startResult.pid
-            });
-            
-            // Enable live features now that server is ready
-            enableLiveFeatures(projectId);
-        } else {
-            console.error('❌ Server failed to start for project:', projectId, startResult.error);
-            updateProjectServerState(projectId, {
-                status: SERVER_STATUS.FAILED,
-                lastError: startResult.error
-            });
-        }
-    } catch (error) {
-        console.error('❌ Error starting server for project:', projectId, error);
-        updateProjectServerState(projectId, {
-            status: SERVER_STATUS.FAILED,
-            lastError: error.message
-        });
-    }
-}
-
-// Update status bar indicator based on server state
-function updateServerStatusIndicator(serverState) {
-    const serverIndicator = document.querySelector('#server-status .status-indicator');
-    const serverIcon = document.querySelector('#server-status .icon');
-    
-    if (!serverIndicator) return;
-    
-    // Clear existing classes
-    serverIndicator.className = 'status-indicator';
-    
-    switch (serverState.status) {
-        case SERVER_STATUS.STARTING:
-            serverIndicator.classList.add('inactive');
-            serverIndicator.parentElement.title = 'Dev server starting...';
-            break;
-        case SERVER_STATUS.READY:
-            serverIndicator.classList.add('active');
-            serverIndicator.parentElement.title = `Dev server ready (${serverState.url})`;
-            break;
-        case SERVER_STATUS.FAILED:
-            serverIndicator.classList.add('error');
-            serverIndicator.parentElement.title = `Dev server failed: ${serverState.lastError}`;
-            break;
-        default:
-            serverIndicator.classList.add('inactive');
-            serverIndicator.parentElement.title = 'Dev server stopped';
-    }
-}
-
-// Enable live features when server becomes ready
-function enableLiveFeatures(projectId) {
-    console.log('🎉 Enabling live features for project:', projectId);
-    
-    // Add live preview buttons to component library
-    addLivePreviewButtons(projectId);
-    
-    // Enable instant workflow previews
-    enableInstantWorkflowPreviews(projectId);
-    
-    // Update UI to show server is ready
-    showServerReadyNotification(projectId);
-}
-
-function addLivePreviewButtons(projectId) {
-    // This will be implemented when we get to the component library enhancement
-    console.log('📝 TODO: Add live preview buttons for components');
-}
-
-function enableInstantWorkflowPreviews(projectId) {
-    // Update workflow cards to show they're ready for instant preview
-    const workflowCards = document.querySelectorAll('.workflow-card');
-    workflowCards.forEach(card => {
-        if (!card.classList.contains('empty-workflow')) {
-            card.classList.add('server-ready');
-        }
-    });
-}
-
-function showServerReadyNotification(projectId) {
-    // Subtle notification that server is ready (optional)
-    console.log('✨ Server ready for instant previews');
-}
-
-// Smart server cleanup and resource management
-function addServerCleanupHandlers() {
-    // Cleanup when navigating back to dashboard
-    const originalShowDashboard = window.showDashboard;
-    if (originalShowDashboard) {
-        window.showDashboard = function() {
-            scheduleServerCleanup();
-            return originalShowDashboard.call(this);
-        };
-    }
-    
-    // Cleanup on app quit
-    window.addEventListener('beforeunload', () => {
-        stopAllProjectServers();
-    });
-}
-
-function scheduleServerCleanup() {
-    // Stop servers after 5 minutes of inactivity (user might come back)
-    setTimeout(() => {
-        if (appContext.currentView === 'dashboard') {
-            console.log('🧹 Cleaning up inactive project servers');
-            stopAllProjectServers();
-        }
-    }, 5 * 60 * 1000); // 5 minutes
-}
-
-async function stopAllProjectServers() {
-    const serverPromises = [];
-    
-    for (const [projectId, serverState] of appState.projectServers) {
-        if (serverState.status === SERVER_STATUS.READY || serverState.status === SERVER_STATUS.STARTING) {
-            console.log('🛑 Stopping server for project:', projectId);
-            serverPromises.push(stopProjectServer(projectId));
-        }
-    }
-    
-    await Promise.all(serverPromises);
-    appState.projectServers.clear();
-}
-
-async function stopProjectServer(projectId) {
-    try {
-        const result = await window.electronAPI.stopProjectServer(projectId);
-        if (result.success) {
-            updateProjectServerState(projectId, {
-                status: SERVER_STATUS.STOPPED,
-                url: null,
-                port: null,
-                pid: null
-            });
-            console.log('✅ Server stopped for project:', projectId);
-        } else {
-            console.error('❌ Failed to stop server for project:', projectId, result.error);
-        }
-    } catch (error) {
-        console.error('❌ Error stopping server for project:', projectId, error);
-    }
-}
-
-// Server failure handling and retry mechanisms
-function handleServerFailure(projectId, error) {
-    console.error('🚨 Server failure for project:', projectId, error);
-    
-    updateProjectServerState(projectId, {
-        status: SERVER_STATUS.FAILED,
-        lastError: error
-    });
-    
-    // Show user-friendly error in UI
-    showServerErrorNotification(projectId, error);
-}
-
-function showServerErrorNotification(projectId, error) {
-    // Update workflow cards to show server error state
-    const workflowCards = document.querySelectorAll('.workflow-card');
-    workflowCards.forEach(card => {
-        card.classList.remove('server-ready');
-        card.classList.add('server-error');
-    });
-}
-
-function retryServerStart(projectId) {
-    console.log('🔄 Retrying server start for project:', projectId);
-    startProjectServerBackground(projectId);
-}
-
-// Initialize server cleanup handlers when app loads
-document.addEventListener('DOMContentLoaded', () => {
-    addServerCleanupHandlers();
-});
 
 // Phase 3: Context Awareness System
 let appContext = {
@@ -286,6 +41,8 @@ let appContext = {
 };
 
 // Pure function constants
+const serverManager = createServerManager({ appState, appContext });
+const { SERVER_STATUS, startProjectServerBackground, stopAllProjectServers, stopProjectServer, getProjectServerState, updateProjectServerState } = serverManager;
 const PROJECT_TEMPLATES = {
     'react-basic': {
         id: 'react-basic',
@@ -4517,4 +4274,5 @@ document.addEventListener('DOMContentLoaded', () => {
     initializeSidebarResize();
     setupGlobalKeyboardShortcuts();
     setupContextAwareness();
+    serverManager.addServerCleanupHandlers();
 });

--- a/index.html
+++ b/index.html
@@ -2209,6 +2209,7 @@
         });
     </script>
     
-    <script src="app.js"></script>
+    <script type="module" src="serverManager.js"></script>
+    <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/lib/thumbnailUtils.js
+++ b/lib/thumbnailUtils.js
@@ -1,0 +1,75 @@
+const path = require('path');
+const os = require('os');
+const fs = require('fs').promises;
+
+function createThumbnailConfig(options = {}) {
+  return {
+    width: options.width || 300,
+    height: options.height || 200,
+    quality: options.quality || 0.8,
+    format: options.format || 'png',
+    timeout: options.timeout || 10000,
+    waitForLoad: options.waitForLoad || 3000,
+    ...options
+  };
+}
+
+function createThumbnailPath(project, config, store) {
+  const projectPath = project.path || path.join(store.get('projectsDirectory', os.homedir()), project.name);
+  const thumbnailDir = path.join(projectPath, '.thumbnails');
+  const timestamp = Date.now();
+  const filename = `preview_${project.id}_${timestamp}.${config.format}`;
+  return path.join(thumbnailDir, filename);
+}
+
+async function shouldRegenerateThumbnail(thumbnailPath, project, maxAge = 3600000) {
+  try {
+    const [thumbStats, projectStats] = await Promise.all([
+      fs.stat(thumbnailPath),
+      fs.stat(path.join(project.path, 'package.json'))
+    ]);
+    const thumbAge = Date.now() - thumbStats.mtime.getTime();
+    const isStale = thumbAge > maxAge;
+    const isOutdated = projectStats.mtime > thumbStats.mtime;
+    return isStale || isOutdated;
+  } catch {
+    return true;
+  }
+}
+
+function createThumbnailWindowConfig(config) {
+  return {
+    width: 1200,
+    height: 800,
+    show: false,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      enableRemoteModule: false,
+      webSecurity: false
+    },
+    paintWhenInitiallyHidden: true,
+    enableLargerThanScreen: true
+  };
+}
+
+function processImageThumbnail(image, config) {
+  return image.resize({
+    width: config.width,
+    height: config.height,
+    quality: 'good'
+  });
+}
+
+function createFallbackThumbnailPath(templateId) {
+  return `fallback:${templateId}`;
+}
+
+module.exports = {
+  createThumbnailConfig,
+  createThumbnailPath,
+  shouldRegenerateThumbnail,
+  createThumbnailWindowConfig,
+  processImageThumbnail,
+  createFallbackThumbnailPath
+};

--- a/lib/windowUtils.js
+++ b/lib/windowUtils.js
@@ -1,0 +1,52 @@
+const { BrowserWindow } = require('electron');
+const path = require('path');
+
+function createWindowConfig() {
+  const isDev = process.argv.includes('--dev');
+  return {
+    width: 1200,
+    height: 800,
+    minWidth: 800,
+    minHeight: 600,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      enableRemoteModule: false,
+      webSecurity: !isDev,
+      preload: path.join(__dirname, '..', 'preload.js')
+    },
+    titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
+    show: false
+  };
+}
+
+function createMainWindow() {
+  const config = createWindowConfig();
+  const window = new BrowserWindow(config);
+  window.loadFile('index.html');
+  window.once('ready-to-show', () => {
+    window.show();
+    if (process.argv.includes('--dev')) {
+      window.webContents.openDevTools();
+    }
+  });
+  if (process.argv.includes('--dev')) {
+    const fs = require('fs');
+    const filesToWatch = ['index.html', 'app.js'];
+    filesToWatch.forEach(file => {
+      fs.watchFile(file, { interval: 1000 }, () => {
+        console.log(`🔄 File changed: ${file}, reloading...`);
+        window.reload();
+      });
+    });
+  }
+  window.on('closed', () => {
+    // mainWindow will be handled in main.js
+  });
+  return window;
+}
+
+module.exports = {
+  createWindowConfig,
+  createMainWindow
+};

--- a/serverManager.js
+++ b/serverManager.js
@@ -1,0 +1,224 @@
+export function createServerManager({ appState, appContext }) {
+  const SERVER_STATUS = {
+    STOPPED: 'stopped',
+    STARTING: 'starting',
+    READY: 'ready',
+    FAILED: 'failed'
+  };
+
+  function createProjectServerState(projectId) {
+    return {
+      projectId,
+      status: SERVER_STATUS.STOPPED,
+      url: null,
+      port: null,
+      pid: null,
+      startTime: null,
+      lastError: null
+    };
+  }
+
+  function updateProjectServerState(projectId, updates) {
+    const currentState = appState.projectServers.get(projectId) || createProjectServerState(projectId);
+    const newState = { ...currentState, ...updates };
+    appState.projectServers.set(projectId, newState);
+    updateServerStatusIndicator(newState);
+    return newState;
+  }
+
+  function getProjectServerState(projectId) {
+    return appState.projectServers.get(projectId) || createProjectServerState(projectId);
+  }
+
+  function isServerReady(projectId) {
+    const state = getProjectServerState(projectId);
+    return state.status === SERVER_STATUS.READY && state.url;
+  }
+
+  async function startProjectServerBackground(projectId) {
+    console.log('🚀 Starting dev server in background for project:', projectId);
+    updateProjectServerState(projectId, {
+      status: SERVER_STATUS.STARTING,
+      startTime: Date.now()
+    });
+    try {
+      const statusResult = await window.electronAPI.getProjectServerStatus(projectId);
+      if (statusResult.success && statusResult.status === 'running') {
+        console.log('✅ Server already running for project:', projectId);
+        updateProjectServerState(projectId, {
+          status: SERVER_STATUS.READY,
+          url: statusResult.url,
+          port: statusResult.port,
+          pid: statusResult.pid
+        });
+        return;
+      }
+      const startResult = await window.electronAPI.startProjectServer(projectId);
+      if (startResult.success) {
+        console.log('✅ Server started successfully for project:', projectId);
+        updateProjectServerState(projectId, {
+          status: SERVER_STATUS.READY,
+          url: startResult.url,
+          port: startResult.port,
+          pid: startResult.pid
+        });
+        enableLiveFeatures(projectId);
+      } else {
+        console.error('❌ Server failed to start for project:', projectId, startResult.error);
+        updateProjectServerState(projectId, {
+          status: SERVER_STATUS.FAILED,
+          lastError: startResult.error
+        });
+      }
+    } catch (error) {
+      console.error('❌ Error starting server for project:', projectId, error);
+      updateProjectServerState(projectId, {
+        status: SERVER_STATUS.FAILED,
+        lastError: error.message
+      });
+    }
+  }
+
+  function updateServerStatusIndicator(serverState) {
+    const serverIndicator = document.querySelector('#server-status .status-indicator');
+    if (!serverIndicator) return;
+    serverIndicator.className = 'status-indicator';
+    switch (serverState.status) {
+      case SERVER_STATUS.STARTING:
+        serverIndicator.classList.add('inactive');
+        serverIndicator.parentElement.title = 'Dev server starting...';
+        break;
+      case SERVER_STATUS.READY:
+        serverIndicator.classList.add('active');
+        serverIndicator.parentElement.title = `Dev server ready (${serverState.url})`;
+        break;
+      case SERVER_STATUS.FAILED:
+        serverIndicator.classList.add('error');
+        serverIndicator.parentElement.title = `Dev server failed: ${serverState.lastError}`;
+        break;
+      default:
+        serverIndicator.classList.add('inactive');
+        serverIndicator.parentElement.title = 'Dev server stopped';
+    }
+  }
+
+  function enableLiveFeatures(projectId) {
+    console.log('🎉 Enabling live features for project:', projectId);
+    addLivePreviewButtons(projectId);
+    enableInstantWorkflowPreviews(projectId);
+    showServerReadyNotification(projectId);
+  }
+
+  function addLivePreviewButtons(projectId) {
+    console.log('📝 TODO: Add live preview buttons for components');
+  }
+
+  function enableInstantWorkflowPreviews(projectId) {
+    const workflowCards = document.querySelectorAll('.workflow-card');
+    workflowCards.forEach(card => {
+      if (!card.classList.contains('empty-workflow')) {
+        card.classList.add('server-ready');
+      }
+    });
+  }
+
+  function showServerReadyNotification(projectId) {
+    console.log('✨ Server ready for instant previews');
+  }
+
+  function addServerCleanupHandlers() {
+    const originalShowDashboard = window.showDashboard;
+    if (originalShowDashboard) {
+      window.showDashboard = function() {
+        scheduleServerCleanup();
+        return originalShowDashboard.call(this);
+      };
+    }
+    window.addEventListener('beforeunload', () => {
+      stopAllProjectServers();
+    });
+  }
+
+  function scheduleServerCleanup() {
+    setTimeout(() => {
+      if (appContext.currentView === 'dashboard') {
+        console.log('🧹 Cleaning up inactive project servers');
+        stopAllProjectServers();
+      }
+    }, 5 * 60 * 1000);
+  }
+
+  async function stopAllProjectServers() {
+    const serverPromises = [];
+    for (const [projectId, serverState] of appState.projectServers) {
+      if (serverState.status === SERVER_STATUS.READY || serverState.status === SERVER_STATUS.STARTING) {
+        console.log('🛑 Stopping server for project:', projectId);
+        serverPromises.push(stopProjectServer(projectId));
+      }
+    }
+    await Promise.all(serverPromises);
+    appState.projectServers.clear();
+  }
+
+  async function stopProjectServer(projectId) {
+    try {
+      const result = await window.electronAPI.stopProjectServer(projectId);
+      if (result.success) {
+        updateProjectServerState(projectId, {
+          status: SERVER_STATUS.STOPPED,
+          url: null,
+          port: null,
+          pid: null
+        });
+        console.log('✅ Server stopped for project:', projectId);
+      } else {
+        console.error('❌ Failed to stop server for project:', projectId, result.error);
+      }
+    } catch (error) {
+      console.error('❌ Error stopping server for project:', projectId, error);
+    }
+  }
+
+  function handleServerFailure(projectId, error) {
+    console.error('🚨 Server failure for project:', projectId, error);
+    updateProjectServerState(projectId, {
+      status: SERVER_STATUS.FAILED,
+      lastError: error
+    });
+    showServerErrorNotification(projectId, error);
+  }
+
+  function showServerErrorNotification(projectId, error) {
+    const workflowCards = document.querySelectorAll('.workflow-card');
+    workflowCards.forEach(card => {
+      card.classList.remove('server-ready');
+      card.classList.add('server-error');
+    });
+  }
+
+  function retryServerStart(projectId) {
+    console.log('🔄 Retrying server start for project:', projectId);
+    startProjectServerBackground(projectId);
+  }
+
+  return {
+    SERVER_STATUS,
+    createProjectServerState,
+    updateProjectServerState,
+    getProjectServerState,
+    isServerReady,
+    startProjectServerBackground,
+    updateServerStatusIndicator,
+    enableLiveFeatures,
+    addLivePreviewButtons,
+    enableInstantWorkflowPreviews,
+    showServerReadyNotification,
+    addServerCleanupHandlers,
+    scheduleServerCleanup,
+    stopAllProjectServers,
+    stopProjectServer,
+    handleServerFailure,
+    showServerErrorNotification,
+    retryServerStart
+  };
+}


### PR DESCRIPTION
## Summary
- extract server management logic to a new `serverManager` module
- load front‑end scripts as ES modules
- move thumbnail and window helpers to `lib`
- clean up `main.js` thumbnail code

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880c8d85bdc832eba0a2d9bf769ae79